### PR TITLE
Fix LdrLoadDll signature, support GetModuleHandleExW, EnumProcessModules 

### DIFF
--- a/memlib.nim
+++ b/memlib.nim
@@ -830,9 +830,9 @@ proc loadString*(lib: MemoryModule, id: UINT, lang: WORD = 0): string
 
 # for hooks
 
-proc LdrLoadDll(PathToFile: PWCHAR, Flags: ULONG, ModuleFileName: PUNICODE_STRING, ModuleHandle: PHANDLE): NTSTATUS {.stdcall, dynlib: "ntdll", importc.}
+proc LdrLoadDll(PathToFile: PWCHAR, Flags: PULONG, ModuleFileName: PUNICODE_STRING, ModuleHandle: PHANDLE): NTSTATUS {.stdcall, dynlib: "ntdll", importc.}
 
-proc myLdrLoadDll(PathToFile: PWCHAR, Flags: ULONG, ModuleFileName: PUNICODE_STRING, ModuleHandle: PHANDLE): NTSTATUS {.stdcall, minhook: LdrLoadDll.} =
+proc myLdrLoadDll(PathToFile: PWCHAR, Flags: PULONG, ModuleFileName: PUNICODE_STRING, ModuleHandle: PHANDLE): NTSTATUS {.stdcall, minhook: LdrLoadDll.} =
   withLock(gLock):
     for i in 0 ..< memLibs.len:
       if memLibs[i].name != nil and lstrcmpiW(ModuleFileName[].Buffer, memLibs[i].name) == 0:

--- a/memlib.nimble
+++ b/memlib.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "1.2.1"
+version       = "1.2.2"
 author        = "Ward"
 description   = "Memlib - Load Windows DLL from memory"
 license       = "MIT"

--- a/memlib.nimble
+++ b/memlib.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "1.2.0"
+version       = "1.2.1"
 author        = "Ward"
 description   = "Memlib - Load Windows DLL from memory"
 license       = "MIT"


### PR DESCRIPTION
This was required to make the hooks work for me without crashing in some situations.

ReactOS has the type as `PULONG` https://doxygen.reactos.org/d7/d55/ldrapi_8c.html#a7671bda932dbb5096570f431ff83474c
![image](https://user-images.githubusercontent.com/2515062/150657332-786351f3-58de-4347-8383-139916108232.png)

I also checked `LoadLibraryExW` (which is the implementation for all `LoadLibrary*`s) and when it calls `LdrLoadDll` it puts a reference into `rdx`.
![image](https://user-images.githubusercontent.com/2515062/150658110-effdf0be-7ef7-4e90-bf70-e6ef50b93055.png)
(Although I have no idea why rcx (SearchPath) is ORed with `0x1` ...)

ntinternals and wine seem to say `Flags` is a ULONG. In wine, they just pass `Flags` from `LoadLibrary*` directly to `LdrLoadDll` rather than referencing.